### PR TITLE
Update django.po

### DIFF
--- a/lucterios/mailing/locale/fr/LC_MESSAGES/django.po
+++ b/lucterios/mailing/locale/fr/LC_MESSAGES/django.po
@@ -38,7 +38,7 @@ msgstr "Message défini pour %d contacts"
 
 #: functions.py:51
 msgid "Email not configure!"
-msgstr "Courriel non configuré!"
+msgstr "Courriel non configuré !"
 
 #: functions.py:113
 msgid "Connection password"
@@ -123,9 +123,9 @@ msgid ""
 "User:%(username)s\n"
 "Password:%(password)s\n"
 msgstr ""
-"Confirmation de connexion à votre application:\n"
-"Alias:%(username)s\n"
-"Mot de passe:%(password)s\n"
+"Confirmation de connexion à votre application :\n"
+"Alias : %(username)s\n"
+"Mot de passe : %(password)s\n"
 
 #: views.py:45
 msgid "Change mailing parameters"
@@ -149,7 +149,7 @@ msgstr "Envoyer"
 
 #: views.py:72
 msgid "Default message"
-msgstr "Messages par défaut"
+msgstr "Message par défaut"
 
 #: views.py:89 views.py:101
 msgid "EMail try"
@@ -217,11 +217,11 @@ msgstr "Courriels"
 
 #: views_message.py:100
 msgid "Send message"
-msgstr "Envoie d'un message"
+msgstr "Envoi d'un message"
 
 #: views_message.py:103
 msgid "Do you want to sent this message?"
-msgstr "Voulez vous envoyer ce message?"
+msgstr "Voulez-vous envoyer ce message ?"
 
 #: views_message.py:106
 #, python-format
@@ -232,7 +232,7 @@ msgstr ""
 
 #: views_message.py:115
 msgid "Delete message"
-msgstr "Suppression d'un messages"
+msgstr "Suppression d'un message"
 
 #: views_message.py:123 views_message.py:135
 msgid "Add recipient to message"
@@ -244,4 +244,4 @@ msgstr "Supprimer un destinataire"
 
 #: views_message.py:148
 msgid "Do you want to delete this recipient?"
-msgstr "Voulez vous supprimer ce destinataire?"
+msgstr "Voulez-vous supprimer ce destinataire ?"


### PR DESCRIPTION
Corrections de fautes d'orthographe et de grammaire.
En français il faut un espace avant un point d'exclamation, d'interrogation ou ":".